### PR TITLE
Update translation of incident-reporting.md

### DIFF
--- a/meetup-organizer/responding-to-code-of-conduct-violations/incident-reporting.md
+++ b/meetup-organizer/responding-to-code-of-conduct-violations/incident-reporting.md
@@ -13,12 +13,12 @@
 <!-- If the report is \*about\* a community organizer, then we’ll reach out to the concerned parties and work to resolve the situation. -->
 報告がコミュニティ主催者についてのものであれば、グローバルコミュニティチームのメンバーは関係者に連絡を取り、状況を解決するために動きます。
 
-<!-- If the report is about behavior that didn’t happen at an “official” event (which is to say, a chapter meetup event, WordCamp, or other workshop organized as part of a global community team program), we’ll request permission to pass the report along to the team it involves (or to the [Escalation Team](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773), currently made up of Josepha Haden Chomphosy, Helen Hou-Sandi, Tammie Lister, Aditya Kane, Morten Rand-Hendriksen, and Jenny Wong).-->
+<!-- If the report is about behavior that didn’t happen at an “official” event (which is to say, a chapter meetup event, WordCamp, or other workshop organized as part of a global community team program), we’ll request permission to pass the report along to the team it involves (or to the [Escalation Team](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773), currently made up of Josepha Haden Chomphosy, Helen Hou-Sandi, Tammie Lister, Aditya Kane, Morten Rand-Hendriksen, and Jenny Wong). -->
 報告が「公式」イベント (チャプター Meetup イベント、WordCamp、その他のグローバルコミュニティチームプログラムとして開催されたワークショップ)以外で起こったことの場合、その報告を関係チーム ([エスカレーションチーム](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773)、現在のメンバーは Josepha Haden Chomphosy、Helen Hou-Sandi、Tammie Lister、Aditya Kane、Morten Rand-Hendriksen、Jenny Wong) に共有するための許可をリクエストします。
 
-<!-- Currently the people who have access to this private mailbox are: Andrea Middleton, Josepha Haden Chomphosy, Cami Kaos, Hugh Lashbrooke, Aditya Kane, Courtney Patubo-Kranzke, and Rocío Valdivia.-->
+<!-- Currently the people who have access to this private mailbox are: Andrea Middleton, Josepha Haden Chomphosy, Cami Kaos, Hugh Lashbrooke, Aditya Kane, Courtney Patubo-Kranzke, and Rocío Valdivia. -->
 現在このプライベートメールボックスにアクセスできるのは、Andrea Middleton、Josepha Haden Chomphosy、Cami Kaos、Hugh Lashbrooke、Aditya Kane、
 Courtney Patubo-Kranzke、Rocío Valdivia です。
 
-<!-- The incident response squad tries to respond to all reports within 72 hours of receiving the report. Resolving the issue reported may take as long as 2-3 months, depending on the nature of the issue.-->
+<!-- The incident response squad tries to respond to all reports within 72 hours of receiving the report. Resolving the issue reported may take as long as 2-3 months, depending on the nature of the issue. -->
 問題対応チームはすべての報告に72時間以内に返信できるように努力しています。問題の性質によっては、解決までに2、3ヶ月かかることもあります。

--- a/meetup-organizer/responding-to-code-of-conduct-violations/incident-reporting.md
+++ b/meetup-organizer/responding-to-code-of-conduct-violations/incident-reporting.md
@@ -1,20 +1,24 @@
 <!-- # Incident Reporting -->
-違反行為の報告
+問題の報告
 
 <!-- To report a code of conduct-related issue, email [report@wordcamp.org](mailto:report@wordcamp.org). Emails sent to this address will go to a private mailbox on the global community team’s Help Scout instance, visible only to deputies on an incident response squad. -->
-行動規範に関する問題を報告するには、E メールを [report@wordcamp.org](mailto:report@wordcamp.org) に送ってください。このアドレスに送信された E メールは、グローバルコミュニティチームのヘルプスカウトインスタンス（メール管理システム）のプライベートメールボックスに送信され、違反行為対応チームのメンバーにのみ表示されます。
+行動規範に関する問題を報告するには、[report@wordcamp.org](mailto:report@wordcamp.org) にメールを送ってください。このアドレスに送信されたメールは、グローバルコミュニティチームの Help Scout （メール管理システム） のプライベートメールボックスに送信され、違反行為対応チームのメンバーにのみ表示されます。
 
 <!-- A stand-alone [Incident Reporting form](https://central.wordcamp.org/incident-report/) is also available, to make it easier for attendees and community members to report issues that come up with their local community organizers, to someone other than their local community organizers. -->
-出席者やコミュニティのメンバーが、自分の地域のコミュニティ主催者との間に起こった問題を、自分の地域のコミュニティ主催者以外の人に報告しやすくするため、独立している[違反行為報告フォーム](https://central.wordcamp.org/incident-report/) も利用できます。
+出席者やコミュニティのメンバーが、自分の地域のコミュニティ主催者との間に起こった問題を本人以外に報告しやすくするための、独立した[問題報告フォーム](https://central.wordcamp.org/incident-report/)も用意しています。
 
 <!-- If the incident response squad receives a report that looks like it could be handled locally — for example, between attendees at a meetup event — a member of the global community team will get in touch with local community organizers to offer assistance. -->
-違反行為対応チームが、地域で処理できるような報告を受信した場合（たとえば、Meetup イベントの出席者の間）、グローバルコミュニティチームのメンバーは、地域のコミュニティ主催者と連絡をとり、支援を提供します。
+問題対応チームが、地域で処理できるような報告を受け取った場合 （たとえば Meetup イベント出席者間の問題）、グローバルコミュニティチームのメンバーは地域コミュニティ主催者と連絡を取り、解決をお手伝いします。
 
 <!-- If the report is \*about\* a community organizer, then we’ll reach out to the concerned parties and work to resolve the situation. -->
 報告がコミュニティ主催者についてのものであれば、グローバルコミュニティチームのメンバーは関係者に連絡を取り、状況を解決するために動きます。
 
-If the report is about behavior that didn’t happen at an “official” event (which is to say, a chapter meetup event, WordCamp, or other workshop organized as part of a global community team program), we’ll request permission to pass the report along to the team it involves (or to the [Escalation Team](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773), currently made up of Josepha Haden Chomphosy, Helen Hou-Sandi, Tammie Lister, Aditya Kane, Morten Rand-Hendriksen, and Jenny Wong).
+<!-- If the report is about behavior that didn’t happen at an “official” event (which is to say, a chapter meetup event, WordCamp, or other workshop organized as part of a global community team program), we’ll request permission to pass the report along to the team it involves (or to the [Escalation Team](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773), currently made up of Josepha Haden Chomphosy, Helen Hou-Sandi, Tammie Lister, Aditya Kane, Morten Rand-Hendriksen, and Jenny Wong).-->
+報告が「公式」イベント (チャプター Meetup イベント、WordCamp、その他のグローバルコミュニティチームプログラムとして開催されたワークショップ)以外で起こったことの場合、その報告を関係チーム ([エスカレーションチーム](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773)、現在のメンバーは Josepha Haden Chomphosy、Helen Hou-Sandi、Tammie Lister、Aditya Kane、Morten Rand-Hendriksen、Jenny Wong) に共有するための許可をリクエストします。
 
-Currently the people who have access to this private mailbox are: Andrea Middleton, Josepha Haden Chomphosy, Cami Kaos, Hugh Lashbrooke, Aditya Kane, Courtney Patubo-Kranzke, and Rocío Valdivia.
+<!-- Currently the people who have access to this private mailbox are: Andrea Middleton, Josepha Haden Chomphosy, Cami Kaos, Hugh Lashbrooke, Aditya Kane, Courtney Patubo-Kranzke, and Rocío Valdivia.-->
+現在このプライベートメールボックスにアクセスできるのは、Andrea Middleton、Josepha Haden Chomphosy、Cami Kaos、Hugh Lashbrooke、Aditya Kane、
+Courtney Patubo-Kranzke、Rocío Valdivia です。
 
-The incident response squad tries to respond to all reports within 72 hours of receiving the report. Resolving the issue reported may take as long as 2-3 months, depending on the nature of the issue.
+<!-- The incident response squad tries to respond to all reports within 72 hours of receiving the report. Resolving the issue reported may take as long as 2-3 months, depending on the nature of the issue.-->
+問題対応チームはすべての報告に72時間以内に返信できるように努力しています。問題の性質によっては、解決までに2、3ヶ月かかることもあります。


### PR DESCRIPTION
最後まで翻訳。
もとは「違反行為の報告」でしたが原文に忠実に「問題の報告」にしました。