### PR TITLE
Update code-of-conduct.md

### DIFF
--- a/meetup-organizer/resources/code-of-conduct.md
+++ b/meetup-organizer/resources/code-of-conduct.md
@@ -1,10 +1,11 @@
 <!-- # Code of Conduct -->
 # 倫理綱領
 
-<!-- Alert: This is a template that may inspire the text for your local meetup group page. Feel free to copy and paste this template and customize it for your area. -->
-注意事項: このページは、あなたの地域の Meetup グループ用に倫理綱領を書いてもらために準備したテンプレートです。このテンプレートをコピーアンドペーストし、あなたの地域に合わるために、自由にカスタマイズしてください。
+<!-- Alert: This is a template that may inspire the text for your local meetup group page. -->
+注意事項: このページは、あなたの地域の Meetup グループ用に倫理綱領を書いてもらために準備したテンプレートです。
 
-Feel free to copy and paste this template and customize it for your area.
+<!-- Feel free to copy and paste this template and customize it for your area. -->
+このテンプレートをコピーアンドペーストし、あなたの地域に合わるために、自由にカスタマイズしてください。
 
 <!-- 1\. Purpose -->
 1\. 目的

--- a/meetup-organizer/resources/code-of-conduct.md
+++ b/meetup-organizer/resources/code-of-conduct.md
@@ -1,8 +1,13 @@
-# Code of Conduct
+<!-- # Code of Conduct -->
+# 倫理綱領
 
-Alert: This is a template that may inspire the text for your local meetup group page.
+<!-- Alert: This is a template that may inspire the text for your local meetup group page. -->
+注意事項: このページは、あなたの地域の Meetup グループの倫理綱領の文章を動機づけるためのテンプレートです。
 
-Feel free to copy and paste this template and customize it for your area.
+
+<!-- Feel free to copy and paste this template and customize it for your area. -->
+このテンプレートをコピーアンドペーストし、あなたの地域に合わるために、自由にカスタマイズしましょう。
+
 
 1\. Purpose
 

--- a/meetup-organizer/resources/code-of-conduct.md
+++ b/meetup-organizer/resources/code-of-conduct.md
@@ -4,6 +4,8 @@
 <!-- Alert: This is a template that may inspire the text for your local meetup group page. Feel free to copy and paste this template and customize it for your area. -->
 注意事項: このページは、あなたの地域の Meetup グループ用に倫理綱領を書いてもらために準備したテンプレートです。このテンプレートをコピーアンドペーストし、あなたの地域に合わるために、自由にカスタマイズしてください。
 
+Feel free to copy and paste this template and customize it for your area.
+
 <!-- 1\. Purpose -->
 1\. 目的
 

--- a/meetup-organizer/resources/code-of-conduct.md
+++ b/meetup-organizer/resources/code-of-conduct.md
@@ -1,66 +1,94 @@
 <!-- # Code of Conduct -->
 # 倫理綱領
 
-<!-- Alert: This is a template that may inspire the text for your local meetup group page. -->
-注意事項: このページは、あなたの地域の Meetup グループの倫理綱領の文章を動機づけるためのテンプレートです。
+<!-- Alert: This is a template that may inspire the text for your local meetup group page. Feel free to copy and paste this template and customize it for your area. -->
+注意事項: このページは、あなたの地域の Meetup グループ用に倫理綱領を書いてもらために準備したテンプレートです。このテンプレートをコピーアンドペーストし、あなたの地域に合わるために、自由にカスタマイズしてください。
 
+<!-- 1\. Purpose -->
+1\. 目的
 
-<!-- Feel free to copy and paste this template and customize it for your area. -->
-このテンプレートをコピーアンドペーストし、あなたの地域に合わるために、自由にカスタマイズしましょう。
+<!-- The WordPress \[your-town\] User Group believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, preferred operating system, programming language, or text editor. -->
+[地域名] WordPress Meetup グループは、自分たちのコミュニティがあらゆる人に対して偽りなくオープンであるべきと考えています。それ故に、私たちは、性別、性的指向、身体障害、民族、宗教、好きな OS、使っているプログラミング言語やテキストエディターにかかわらず、すべての人に友好的で安全で快適な環境を提供していくことに全力で取り組んでいるのです。
 
+<!-- This code of conduct outlines our expectations for participant behavior as well as the consequences for unacceptable behavior. -->
+この倫理綱領では、私たちが参加者に対して求めている振る舞いと、受け入れ難い行為を行うとどのような結果を招くのか説明しています。
 
-1\. Purpose
+<!-- We invite all sponsors, volunteers, speakers, attendees, and other participants to help us realize a safe and positive community experience for everyone. -->
+誰にとっても安全で有益なコミュニティ体験の場が実現するよう、私たちは、すべてのスポンサー、ボランティア、スピーカー、一般来場者、それ以外の関係者にも協力をお願いしています。 -->
 
-The WordPress \[your-town\] User Group believes our community should be truly open for everyone. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, preferred operating system, programming language, or text editor.
+<!-- 2\. Open Source Citizenship -->
+2\. オープンソース市民
 
-This code of conduct outlines our expectations for participant behavior as well as the consequences for unacceptable behavior.
+<!-- A supplemental goal of this code of conduct is to increase open source citizenship by encouraging participants to recognize and strengthen the relationships between what we do and the community at large. -->
+私たちの役割とコミュニティ全体との関わり合いを関係者が認め強化するように働き掛けることで、オープンソース市民を増やしていくことがこの倫理綱領のもう一つの目的です。
 
-We invite all sponsors, volunteers, speakers, attendees, and other participants to help us realize a safe and positive community experience for everyone.
+<!-- In service of this goal, the WordPress \[your-town\] User Group organizers will be taking nominations for exemplary citizens. -->
+この目的を達成するために、[地域名] WordPress Meetup グループは、称賛に値する市民の推薦を受け付けています。
 
-2\. Open Source Citizenship
+<!-- If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know. You can nominate someone by talking to the event organizer or online. -->
+私たちのコミュニティが心地良く友好的な場であることを保証し、すべての関係者が最大限に貢献してくれるよう働き掛けるため、人一倍の努力をしている「市民」を見かけたら、私たちに推薦してください。イベントオーガナイザーに直接伝えるか、オンラインから推薦してください。
 
-A supplemental goal of this code of conduct is to increase open source citizenship by encouraging participants to recognize and strengthen the relationships between what we do and the community at large.
+<!-- 3\. Expected Behavior -->
+3\. 求められる振る舞い
 
-In service of this goal, the WordPress \[your-town\] User Group organizers will be taking nominations for exemplary citizens.
+*   思いやりを持ち、礼儀正しく、協力し合うこと。<!-- Be considerate, respectful, and collaborative. -->
+*   他人が屈辱的、差別的、迷惑に感じる振る舞いや発言はやめること。<!-- Refrain from demeaning, discriminatory or harassing behavior and speech. -->
+*   周囲の状況や、仲間である他の参加者に気を配ること。<!-- Be mindful of your surroundings and of your fellow participants. -->
+*   危険な状況や、苦しんでいる人に気づいたらコミュニティ主催者に伝えること。<!-- Alert community organizers if you notice a dangerous situation or someone in distress. -->
+*   偽ることなく、積極的に参加すること。このように振る舞うことが、[地域名] WordPress Meetup グループを形作ることを助け、結果的にユーザーグループがあなた自身の場にもなっていきます。<!-- Participate in an authentic and active way. In doing so, you help to create WordPress \[your-town\] User Group and make it your own. -->
 
-If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know. You can nominate someone by talking to the event organizer or online.
+<!-- 4\. Unacceptable Behavior -->
+4\. 受け入れ難い行為
 
-3\. Expected Behavior
+<!-- Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning conduct by any members of  WordPress \[your-town\] User Group and related events. All WordPress \[your-town\] User Group venues may be shared with members of the public; please be respectful to all patrons of these locations. -->
+受け入れ難い行為は以下の行動を含みます。
+*   [地域名] WordPress Meetup グループのメンバー、もしくは関連するイベントによる、他人への威嚇、迷惑、虐待、差別、名誉毀損、屈辱行為。
+*   [地域名] WordPress Meetup グループが使う会場は一般の人々も使うことが考えられます。そういった場所では、他のお客さまにも礼儀正しくしてください。
 
-*   Be considerate, respectful, and collaborative.
-*   Refrain from demeaning, discriminatory or harassing behavior and speech.
-*   Be mindful of your surroundings and of your fellow participants.
-*   Alert community organizers if you notice a dangerous situation or someone in distress.
-*   Participate in an authentic and active way. In doing so, you help to create WordPress \[your-town\] User Group and make it your own.
+<!-- Harassment includes: offensive verbal comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention. -->
+迷惑行為には以下の振る舞いが含まれます。
+*   性別、性的指向、人種、宗教、身体障害に関する、言葉による攻撃的な意見。
+*   公共空間 (プレゼンテーションのスライドを含む) における、裸体や性的画像の不適切な使用。
+*   意図的な脅迫、ストーキング、尾行。
+*   嫌がらせとなるような写真・ビデオ撮影と録音。
+*   トークやイベントの持続した途絶を招く行為。
+*   不適切な身体的接触と、不愉快な性的注目。
 
-4\. Unacceptable Behavior
+<!-- 5\. Consequences Of Unacceptable Behavior -->
+5\. 受け入れ難い行為が招く結果
 
-Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning conduct by any members of  WordPress \[your-town\] User Group and related events. All WordPress \[your-town\] User Group venues may be shared with members of the public; please be respectful to all patrons of these locations.
+<!-- Unacceptable behavior will not be tolerated whether by other attendees, organizers, venue staff, sponsors, or other patrons of the WordPress \[your-town\] User Group venues. -->
+受け入れ難い行為は、一般来場者、オーガナイザー、会場スタッフ、スポンサー、[地域名] WordPress Meetup グループの会場に来ている他のお客さま、であろうとなかろうと許されません。
 
-Harassment includes: offensive verbal comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.
+<!-- Anyone asked to stop unacceptable behavior is expected to comply immediately. -->
+受け入れ難い行為を止めるように要求された人は、直ぐに従うことが求められます。
 
-5\. Consequences Of Unacceptable Behavior
+<!-- If a participant engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including expulsion from the community without warning or refund. -->
+受け入れ難い行為に関与した参加者がでた場合、最大で「事前警告や参加費などの返金をせずにコミュニティからの除名処分」に至るまで、コミュニティ主催者は自身が適切だと判断した行動を取ることができます。
 
-Unacceptable behavior will not be tolerated whether by other attendees, organizers, venue staff, sponsors, or other patrons of the WordPress \[your-town\] User Group venues.
+<!-- 6\. What To Do If You Witness Or Are Subject To Unacceptable Behavior -->
+受け入れ難い行為を目撃したり、被害に遭った場合は
 
-Anyone asked to stop unacceptable behavior is expected to comply immediately.
+<!-- If you are subjected to unacceptable behavior, notice that someone else is being subject to unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible or fill out an incident report if the incident was online. -->
+受け入れ難い行為を受けたり、他の人がそのような行為を受けているのに気付いたり、その他にも気になることがあれば、できるだけ早くコミュニティ主催者にお知らせいただくか、オンラインで起こった出来事であれば、「迷惑行為などの報告」に記入をお願いします。
 
-If a participant engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including expulsion from the community without warning or refund.
+<!-- The WordPress \[your-town\] User Group team will be available to help participants contact venue security or local law enforcement, to provide escorts, or to otherwise assist those experiencing unacceptable behavior to feel safe in the community. -->
+[地域名] WordPress Meetup グループチームは、参加者が、会場の警備担当者や地元の警察と連絡を取るのを助けたり、付き添う人を用意したり、受け入れ難い行為にさらされている人がコミュニティで安心できるよう手助けをします。
 
-6\. What To Do If You Witness Or Are Subject To Unacceptable Behavior
+<!-- 7\. Scope -->
+7\. 適用範囲
 
-If you are subjected to unacceptable behavior, notice that someone else is being subject to unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible or fill out an incident report if the incident was online.
+<!-- We expect all community members, sponsors, volunteers, speakers, attendees, and other guests to abide by this code of conduct at all venues and related social events. -->
+すべてのコミュニティ参加者、スポンサー、ボランティア、スピーカー、一般来場者、その他のゲストが、すべての会場および関連する社交イベントにおいて、この倫理綱領を順守することを、私たちは要求します。
 
-The WordPress \[your-town\] User Group team will be available to help participants contact venue security or local law enforcement, to provide escorts, or to otherwise assist those experiencing unacceptable behavior to feel safe in the community.
+<!-- 8\. Contact Information -->
+8\. 連絡先情報
 
-7\. Scope
+<!-- We are available via the ‘Contact’ button over in the left hand sidebar -->
+左側のサイドバーにある「コンタクト」ボタンで、主催者に連絡できます。
 
-We expect all community members, sponsors, volunteers, speakers, attendees, and other guests to abide by this code of conduct at all venues and related social events.
+<!-- 9\. License And Attribution -->
+9\. ライセンスと帰属
 
-8\. Contact Information
-
-We are available via the ‘Contact’ button over in the left hand sidebar
-
-9\. License And Attribution
-
-This Code of Conduct is heavily borrowed from the awesome work of Open Source Bridge. The original is available at [http://opensourcebridge.org/about/code-of-conduct/](http://opensourcebridge.org/about/code-of-conduct/) and is released under a Creative Commons Attribution-ShareAlike license.
+<!-- This Code of Conduct is heavily borrowed from the awesome work of Open Source Bridge. The original is available at [http://opensourcebridge.org/about/code-of-conduct/](http://opensourcebridge.org/about/code-of-conduct/) and is released under a Creative Commons Attribution-ShareAlike license. -->
+Open Source Bridge の素晴らしい著作物を取り入れる形で、この倫理綱領は作られています。オリジナルは http://opensourcebridge.org/about/code-of-conduct/ で入手でき、クリエイティブ·コモンズ表示-継承ライセンスのもとでリリースされています。


### PR DESCRIPTION
翻訳を開始しました。まずは前文の部分を翻訳しました。

この Code of Conduct ですが、前文に「これはテンプレートである」と書いてありますので、行動規範とせずに、倫理綱領としました。

参考 = https://kotobank.jp/word/%E5%80%AB%E7%90%86%E7%B6%B1%E9%A0%98-9871