### PR TITLE
一部、原文参照するよう更新。

### DIFF
--- a/meetup-organizer/responding-to-code-of-conduct-violations/incident-reporting.md
+++ b/meetup-organizer/responding-to-code-of-conduct-violations/incident-reporting.md
@@ -14,10 +14,10 @@
 報告がコミュニティ主催者についてのものであれば、グローバルコミュニティチームのメンバーは関係者に連絡を取り、状況を解決するために動きます。
 
 <!-- If the report is about behavior that didn’t happen at an “official” event (which is to say, a chapter meetup event, WordCamp, or other workshop organized as part of a global community team program), we’ll request permission to pass the report along to the team it involves (or to the [Escalation Team](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773), currently made up of Josepha Haden Chomphosy, Helen Hou-Sandi, Tammie Lister, Aditya Kane, Morten Rand-Hendriksen, and Jenny Wong). -->
-報告が「公式」イベント (公認 WordPress Meetup イベント、WordCamp、その他のグローバルコミュニティチームプログラムとして開催されたワークショップ) 以外で起こったことの場合、問題に関わっているチーム (もしくは [エスカレーションチーム](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773)、現在のメンバーは Josepha Haden Chomphosy、Helen Hou-Sandi、Tammie Lister、Aditya Kane、Morten Rand-Hendriksen、Jenny Wong) に報告内容を知らせるための許可をリクエストします。
+報告が「公式」イベント (公認 WordPress Meetup イベント、WordCamp、その他のグローバルコミュニティチームプログラムとして開催されたワークショップ) 以外で起こったことの場合、問題に関わっているチーム (もしくは [エスカレーションチーム](https://make.wordpress.org/community/2015/07/02/escalation-team/#comment-22773)) に報告内容を知らせるための許可をリクエストします。
 
 <!-- Currently the people who have access to this private mailbox are: Andrea Middleton, Josepha Haden Chomphosy, Cami Kaos, Hugh Lashbrooke, Aditya Kane, Courtney Patubo-Kranzke, and Rocío Valdivia. -->
-現在このプライベートメールボックスにアクセスできるのは、Andrea Middleton、Josepha Haden Chomphosy、Cami Kaos、Hugh Lashbrooke、Aditya Kane、Courtney Patubo-Kranzke、Rocío Valdivia です。
+現在エスカレーションチームのメンバーおよびプライベートメールボックスにアクセスできるメンバーについては[原文](https://make.wordpress.org/community/handbook/meetup-organizer/responding-to-code-of-conduct-violations/incident-reporting/)を参照してください。
 
 <!-- The incident response squad tries to respond to all reports within 72 hours of receiving the report. Resolving the issue reported may take as long as 2-3 months, depending on the nature of the issue. -->
 問題対応チームはすべての報告に72時間以内に返信できるように努力しています。問題の性質によっては、解決までに2、3ヶ月かかることもあります。


### PR DESCRIPTION
ページ公開にあたって、変更される可能性がある人名について原文との差異が生まれないようにした。

公開ページはこちら
https://ja.wordpress.org/team/handbook/esponding-to-code-of-conduct-violation/incident-reporting/