### PR TITLE
タイトル他微調整

### DIFF
--- a/meetup-organizer/when-a-group-leaves-the-chapter-program.md
+++ b/meetup-organizer/when-a-group-leaves-the-chapter-program.md
@@ -1,21 +1,21 @@
 <!-- # When a Group Leaves the Chapter Program -->
-# WordPress Meetup のチャプタープログラムを閉じるもしくは離れたい時
+# グループがチャプタープログラムから離脱する場合
 
 <!-- Sometimes a group will leave the chapter program. Reasons include: -->
-グループがチャプタープログラムを離れることもあります。 理由は以下の通りです。
+グループがチャプタープログラムを離れることもあります。理由には以下のようなものがあります。
 
 <!-- 1.  The lead organizer needs to step down and cannot find a replacement. -->
-1.  リードオーガナイザーは辞任するが、代わりのオーガナイザーを見つけることができない。
+1.  リードオーガナイザーが辞任するが、代わりのオーガナイザーを見つけることができない。
 <!-- 2.  The group hasn’t had an event in 6 or more months, and the organizer doesn’t have plans to organize another event. -->
 2.  半年以上イベントを開催しておらず、オーガナイザーは以後のイベントを計画する予定がない。
 <!-- 3.  A group decides they no longer want to be part of the chapter. -->
-3.  WordPress Meetup のチャプターの一部になりたくないと決めた時。
+3.  グループが、WordPress Meetup のチャプターの一部になりたくないと決めた時。
 
 <!-- In the first two cases, the Community Team makes an effort to find new organizers for the group, and if that effort doesn’t result in a new organizer volunteering, the group will be removed from the chapter program. -->
-最初の2つのケースでは、コミュニティチームがグループの新しいオーガナイザーを見つけるために努力し、しかし新しいオーガナイザーが見つからない場合、そのグループはチャプタープログラムから削除されます。
+最初の2つのケースでは、コミュニティチームがグループの新しいオーガナイザーを探します。それでも新しいオーガナイザーが見つからない場合、そのグループはチャプタープログラムから削除されます。
 
 <!-- When a Meetup group is removed from the WordPress chapter account, WordPress steps down as the organizer. WordPress will no longer pay the dues for the account since WP is no longer the owner of the group. -->
-Meetup グループが 公認 WordPress Meetup のチャプターアカウントから削除されると、WordPress はオーガナイザーとして辞任します。 WordPress はグループの所有者ではなくなるため、WordPress はアカウントの会費を支払うことはありません。
+Meetup グループが 公認 WordPress Meetup のチャプターアカウントから削除されると、WordPress アカウントはオーガナイザーとして辞任します。 WordPress アカウントはグループの所有者ではなくなるため、会費の支払いはされなくなります。
 
 <!-- Since there will also not be any other organizers, no one else will be charged dues until another member becomes the organizer. If a group becomes active again, and and the new or now-active organizers would like to re-join the chapter, they should complete the [Meetup Interest Form](https://make.wordpress.org/community/handbook/meetup-organizer/getting-started/interest-form/). -->
-他のオーガナイザーもいないので、他のメンバーがオーガナイザーになるまで、誰も会費を請求されません。 グループが再度アクティブになり、新しいまたは現在アクティブなオーガナイザーがチャプターに再参加したい場合、[Meetup 応募フォーム](https://ja.wordpress.org/get-involved/meetup/meetup-interest-form/)から申請する必要があります。
+他のオーガナイザーもいないので、他のメンバーがオーガナイザーになるまで、誰も会費を請求されません。グループが再度アクティブになり、新規または現在アクティブになったオーガナイザーがチャプターに再参加したい場合は、[Meetup 応募フォーム](https://ja.wordpress.org/get-involved/meetup/meetup-interest-form/)から申請する必要があります。


### PR DESCRIPTION
公開にあたって、タイトルが長いためサイドバーで折り返されるので短縮。その他調整。
https://ja.wordpress.org/team/handbook/when-a-group-leaves-the-chapter-program/